### PR TITLE
Show brightness value only when it is supported

### DIFF
--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -250,7 +250,12 @@
                   if(entity.state == 'off'){
                     return '{{ _d_t_trans.light.off_text }}';
                   } else {
-                    return '{{ _d_t_trans.light.on_text }}, ' + Math.round(((states['{{ room["light"] }}'].attributes.brightness/255)*100)) + '%';
+                    if (states['{{ room["light"] }}'].attributes && (states['{{ room["light"] }}'].attributes.brightness <= 255)) { 
+                      var bri = Math.round(states['{{ room["light"] }}'].attributes.brightness / 2.55); 
+                      return '{{ _d_t_trans.light.on_text }}, ' + (bri ? bri : '0') + '%'; 
+                    } else {
+                      return '{{ _d_t_trans.light.on_text }}';
+                    }
                   }
                 } else {
                   console.log("Invalid rooms.yaml:{{ room["name"] }}.light entity!");


### PR DESCRIPTION
Not all lights support brightness attribute. For instance you can create a light from a switch (https://www.home-assistant.io/integrations/light.switch/). When such light is turned on, it displays NaN% for brightness, if it's the only light in the room.