### PR TITLE
Add Light notifications (Toast)

### DIFF
--- a/packages/dwains-theme/dwains_theme_configuration.yaml
+++ b/packages/dwains-theme/dwains_theme_configuration.yaml
@@ -49,6 +49,33 @@ input_select:
 
 #Theme automations
 automation:
+  #Light Toast notification (Can be extended to all other domains!)
+  - alias: Notify State Change Light
+    initial_state: true
+    trigger:
+      - platform: event
+        event_type: state_changed
+    condition:
+      - condition: template
+        value_template: "{{ trigger.event.data.entity_id is not none }}"
+      - condition: template
+        value_template: >
+          {% set domain = trigger.event.data.entity_id.split('.')[0] %}
+          {% if domain == 'light' %} # << change this domain to get notificatons for other domains
+            True
+          {% else %}
+            False
+          {% endif %}
+      - condition: template
+        value_template: "{{ trigger.event.data.old_state.state !=  trigger.event.data.new_state.state }}"
+    action:
+      - service: browser_mod.toast
+        data_template:
+          duration: 6000
+          message: >-
+            {% set e = trigger.event.data.entity_id %}
+            {% set friendly_name = states[e.split('.')[0]][e.split('.')[1]].attributes.friendly_name %}
+            {{ friendly_name }} turned {{ trigger.event.data.new_state.state }}
   #Theme Selector
   - alias: 'themes'
     initial_state: 'true'

--- a/packages/dwains-theme/dwains_theme_configuration.yaml
+++ b/packages/dwains-theme/dwains_theme_configuration.yaml
@@ -68,6 +68,9 @@ automation:
           {% endif %}
       - condition: template
         value_template: "{{ trigger.event.data.old_state.state !=  trigger.event.data.new_state.state }}"
+      - condition: state
+        entity_id: input_boolean.light_notify # turned on by default???
+        state: 'on'
     action:
       - service: browser_mod.toast
         data_template:


### PR DESCRIPTION
I thought it might be a real niche feature to get notifications which lights turned on or off. It is compatible to all kind of Home Assistant setups as it works via domain and reads out firendly name and state :)