### PR TITLE
added input_boolean opt-out for light notifications

### DIFF
--- a/packages/dwains-theme/dwains_theme_configuration.yaml
+++ b/packages/dwains-theme/dwains_theme_configuration.yaml
@@ -34,6 +34,13 @@ sensor:
     select: ".current-version h1"
     value_template: '{{ value.split(":")[1] }}'
 
+#Input boolean
+input_boolean:
+  # Toast Light Notifications
+  light_notify:
+    initial: on
+    name: Lightyfy # Thought that might be a nice name :)    
+
 #Input select
 input_select:
   #Theme selector


### PR DESCRIPTION
I added the input boolean for the light notifications. I called it Lightyfy :) We might want to change this if the name is not appropriated enough. Thought it might give it a nice touch