### PR TITLE
Fixed Crash in house_information.yaml | Various changes more detailed information in comments

### DIFF
--- a/dwains-theme/views/main/more_page/house_information.yaml
+++ b/dwains-theme/views/main/more_page/house_information.yaml
@@ -72,6 +72,7 @@
               {% endif %}
               {% endif %}
 
+              {% if _d_t_config.house_information %}
               {% if _d_t_config.house_information["addons"] %}
               {% for addon in _d_t_config.house_information["addons"] %}
               - type: vertical-stack
@@ -85,7 +86,8 @@
                       {% endif %}
               {% endfor %}
               {% endif %}
-
+              {% endif %}
+              
               #All activity (doors, windows, motion)
               - !include
                 - ../../partials/heading.yaml

--- a/www/dwains-theme/plugins/dwains-cover-card/dwains-cover-card.js
+++ b/www/dwains-theme/plugins/dwains-cover-card/dwains-cover-card.js
@@ -29,8 +29,8 @@ class DwainsCoverCard extends LitElement {
             ? stateObj.entity_id.split(".")[1].replace(/_/g, " ")
             : stateObj.attributes.friendly_name;
 
-    if(stateObj.attributes.supported_features == 15 || stateObj.attributes.supported_features == 7){
-      //Cover has support for position (15 or 7)
+    if(stateObj.attributes.supported_features & 7 > 0){
+      //Cover has flags for position active
       return html`
         <ha-card
             .header=${this.config.title || name}>


### PR DESCRIPTION
Fixing a rendering crash if house_information.yaml is empty

Callstack:
```
Logger: homeassistant.components.websocket_api.http.connection.2831395312
Source: dwains-theme/views/main/more_page/house_information.yaml:75
Integration: Home Assistant WebSocket API (documentation, issues)
First occurred: 22:30:06 (3 occurrences)
Last logged: 22:30:18

Error handling message: Unknown error
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 20, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/lovelace/websocket.py", line 30, in send_with_error_handling
    result = await func(hass, connection, msg, config)
  File "/usr/src/homeassistant/homeassistant/components/lovelace/websocket.py", line 72, in websocket_lovelace_config
    return await config.async_load(msg["force"])
  File "/usr/src/homeassistant/homeassistant/components/lovelace/dashboard.py", line 186, in async_load
    self._load_config, force
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/lovelace/dashboard.py", line 204, in _load_config
    config = load_yaml(self.path)
  File "/usr/src/homeassistant/homeassistant/util/yaml/loader.py", line 61, in load_yaml
    return yaml.load(conf_file, Loader=SafeLineLoader) or OrderedDict()
  File "/usr/local/lib/python3.7/site-packages/yaml/__init__.py", line 114, in load
    return loader.get_single_data()
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 51, in get_single_data
    return self.construct_document(node)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 55, in construct_document
    data = self.construct_object(node)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 100, in construct_object
    data = constructor(self, node)
  File "/usr/src/homeassistant/homeassistant/util/yaml/loader.py", line 192, in _ordered_dict
    nodes = loader.construct_pairs(node)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 155, in construct_pairs
    value = self.construct_object(value_node, deep=deep)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 100, in construct_object
    data = constructor(self, node)
  File "/usr/src/homeassistant/homeassistant/util/yaml/loader.py", line 183, in _include_dir_merge_list_yaml
    loaded_yaml = load_yaml(fname)
  File "/config/custom_components/dwains_theme/__init__.py", line 156, in load_yaml
    "_d_t_styles": dwains_theme_styles
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.7/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/config/dwains-theme/views/main/more_page/house_information.yaml", line 75, in top-level template code
    #              {% if _d_t_config.house_information["addons"] %}
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 452, in getitem
    return obj[argument]
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'house_information'
```