### PR TITLE
Remove Duplicate key - app-header-background-color

### DIFF
--- a/themes/dwains-theme-black.yaml
+++ b/themes/dwains-theme-black.yaml
@@ -65,7 +65,5 @@ dwains-theme-black:
   switch-checked-track-color: '#515357'                # Background On
   switch-unchecked-track-color: '#131314'              # Background Off
 
-  app-header-background-color: '#121212'
-
   #iOS app
   app-header-background-color: 'var(--dwains-theme-primary)'


### PR DESCRIPTION
Theme had a duplicate key, removed the key that hardcoded the color in favour of the key that used the variable