### PR TITLE
Hold press doesn't open the more info

### DIFF
--- a/dwains-theme/views/main/devices/devices.yaml
+++ b/dwains-theme/views/main/devices/devices.yaml
@@ -58,7 +58,7 @@
                             - entity: {{ room["device"] }}
                           double_tap_action:
                             !include
-                            - ../../popups/light.yaml
+                            - ../../popups/more-info.yaml
                             - entity: {{ room["device"] }}
                   {% else %}
                   # this room has group of devices
@@ -78,7 +78,7 @@
                               - entity: this.entity_id
                             double_tap_action:
                               !include
-                              - ../../popups/light.yaml
+                              - ../../popups/more-info.yaml
                               - entity: this.entity_id
                     sort:
                       method: name

--- a/dwains-theme/views/main/devices/devices.yaml
+++ b/dwains-theme/views/main/devices/devices.yaml
@@ -50,9 +50,16 @@
                           template: room_device
                           entity: {{ room["device"] }}
                           tap_action:
-                            !include 
-                              - ../../popups/more-info.yaml
-                              - entity: this.entity_id
+                            action: toggle
+                            haptic: light
+                          hold_action:
+                            !include
+                            - ../../popups/more-info.yaml
+                            - entity: {{ room["device"] }}
+                          double_tap_action:
+                            !include
+                            - ../../popups/light.yaml
+                            - entity: {{ room["device"] }}
                   {% else %}
                   # this room has group of devices
                   - type: custom:auto-entities
@@ -63,9 +70,16 @@
                             type: custom:button-card
                             template: room_device
                             tap_action:
-                              !include 
-                                - ../../popups/more-info.yaml
-                                - entity: this.entity_id
+                              action: toggle
+                              haptic: light
+                            hold_action:
+                              !include
+                              - ../../popups/more-info.yaml
+                              - entity: this.entity_id
+                            double_tap_action:
+                              !include
+                              - ../../popups/light.yaml
+                              - entity: this.entity_id
                     sort:
                       method: name
                       ignore_case: true

--- a/dwains-theme/views/main/devices/lights.yaml
+++ b/dwains-theme/views/main/devices/lights.yaml
@@ -57,11 +57,11 @@
                           {% if room["light"].split('.')[0] == 'light' %}
                           hold_action:
                             !include
-                              - ../../popups/more-info.yaml
+                              - ../../popups/light.yaml
                               - entity: {{ room["light"] }}
                           double_tap_action:
                             !include
-                              - ../../popups/more-info.yaml
+                              - ../../popups/light.yaml
                               - entity: {{ room["light"] }}
                           {% endif %}
                   {% else %}

--- a/dwains-theme/views/main/devices/lights.yaml
+++ b/dwains-theme/views/main/devices/lights.yaml
@@ -56,12 +56,12 @@
                           entity: {{ room["light"] }}
                           {% if room["light"].split('.')[0] == 'light' %}
                           hold_action:
-                            !include 
-                              - ../../popups/light.yaml
+                            !include
+                              - ../../popups/more-info.yaml
                               - entity: {{ room["light"] }}
                           double_tap_action:
-                            !include 
-                              - ../../popups/light.yaml
+                            !include
+                              - ../../popups/more-info.yaml
                               - entity: {{ room["light"] }}
                           {% endif %}
                   {% else %}
@@ -74,11 +74,11 @@
                             type: custom:button-card
                             template: room_light
                             hold_action:
-                              !include 
+                              !include
                                 - ../../popups/light.yaml
-                                - entity: {{ room["light"] }}
+                                - entity: this.entity_id
                             double_tap_action:
-                              !include 
+                              !include
                                 - ../../popups/light.yaml
                                 - entity: this.entity_id
                     sort:

--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -287,8 +287,12 @@
                 tap_action:
                   action: toggle
                   haptic: light 
+                hold_action:
+                  !include
+                    - ../../popups/light.yaml
+                    - entity: {{ room["light"] }}
                 double_tap_action:
-                  !include 
+                  !include
                     - ../../popups/light.yaml
                     - entity: {{ room["light"] }}
                 label: >
@@ -473,6 +477,14 @@
                 tap_action:
                   action: toggle
                   haptic: light 
+                hold_action:
+                  !include
+                    - ../../popups/more-info.yaml
+                    - entity: {{ room["device"] }}
+                double_tap_action:
+                  !include
+                    - ../../popups/more-info.yaml
+                    - entity: {{ room["device"] }}
                 label: >
                   [[[ 
                     if(entity){

--- a/dwains-theme/views/main/rooms/room/devices.yaml
+++ b/dwains-theme/views/main/rooms/room/devices.yaml
@@ -38,9 +38,16 @@
                     type: custom:button-card
                     template: room_device
                     tap_action:
-                      !include 
-                        - ../../../popups/more-info.yaml
-                        - entity: this.entity_id
+                      action: toggle
+                      haptic: light
+                    hold_action:
+                      !include
+                      - ../../../popups/more-info.yaml
+                      - entity: this.entity_id
+                    double_tap_action:
+                      !include
+                      - ../../../popups/light.yaml
+                      - entity: this.entity_id
             sort:
               method: name
               ignore_case: true

--- a/dwains-theme/views/main/rooms/room/devices.yaml
+++ b/dwains-theme/views/main/rooms/room/devices.yaml
@@ -46,7 +46,7 @@
                       - entity: this.entity_id
                     double_tap_action:
                       !include
-                      - ../../../popups/light.yaml
+                      - ../../../popups/more-info.yaml
                       - entity: this.entity_id
             sort:
               method: name

--- a/dwains-theme/views/popups/light.yaml
+++ b/dwains-theme/views/popups/light.yaml
@@ -5,7 +5,7 @@ haptic: heavy
 action: call-service
 service: browser_mod.popup
 service_data:
-  title: '[[[ return entity.attributes.friendly_name ]]]'
+  title: ' '
   card:
     type: vertical-stack
     cards:
@@ -27,5 +27,6 @@ service_data:
         show_slider_percent: true
         smooth_color_wheel: true
         header: false
+        hide_header: true
   deviceID:
     - this

--- a/dwains-theme/views/popups/more-info.yaml
+++ b/dwains-theme/views/popups/more-info.yaml
@@ -5,7 +5,7 @@ haptic: heavy
 action: call-service
 service: browser_mod.popup
 service_data:
-  title: '[[[ return entity.attributes.friendly_name ]]]'
+  title: ' '
   card:
     type: vertical-stack
     cards:


### PR DESCRIPTION
These changes provide consistent behaviour for lights and devices in all areas for me (only changes lights & devices, since I dont really have locked, etc.)

**Room card**:
*Lights - single*:
*tap*: toggle on / off
*double tap*: more info (light pop-up)
*tap & hold*: more info (light pop-up)

*Lights - inside group*:
*tap*: toggle on / off
*double tap*: more info (light pop-up)
*tap & hold*: more info (light pop-up)

*Devices - single*:
*tap*: toggle on / off
*double tap*: more info (more-info pop-up)
*tap & hold*: more info (more-info pop-up)

*Devices - inside group*:
*tap*: toggle on / off
*double tap*: more info (more-info pop-up)
*tap & hold*: more info (more-info pop-up)

**Devices card**:
*Lights - single*:
*tap*: toggle on / off
*double tap*: more info (light pop-up)
*tap & hold*: more info (light pop-up)

*Lights - inside group*:
*tap*: toggle on / off
*double tap*: more info (light pop-up)
*tap & hold*: more info (light pop-up)

*Devices - single*:
*tap*: toggle on / off
*double tap*: more info (more-info pop-up)
*tap & hold*: more info (more-info pop-up)

*Devices - inside group*:
*tap*: toggle on / off
*double tap*: more info (more-info pop-up)
*tap & hold*: more info (more-info pop-up)

**Other changes**:
pop-ups/light.yaml:
 - Added: ```hide_header: true```
 - Removed title (I think it looks less cluttered).

pop-ups/more-info.yaml:
 - Removed title (I think it looks less cluttered).