### PR TITLE
Remove hard navigation link

### DIFF
--- a/dwains-theme/views/partials/header.yaml
+++ b/dwains-theme/views/partials/header.yaml
@@ -24,7 +24,12 @@ card:
       show_label: true
       tap_action: 
         action: navigate
-        navigation_path: /dwains-theme/{{ navigation_path }}
+        navigation_path: >
+          [[[
+            let path = window.location.pathname;
+            let sub_path = path.substring(0, path.lastIndexOf('/'));
+            return sub_path + "/{{ navigation_path }}";
+          ]]]
       label: > 
         [[[         
           return `<ha-icon

--- a/dwains-theme/views/partials/header_grid.yaml
+++ b/dwains-theme/views/partials/header_grid.yaml
@@ -27,7 +27,12 @@ card:
           show_label: true
           tap_action: 
             action: navigate
-            navigation_path: /dwains-theme/{{ navigation_path }}
+            navigation_path: >
+              [[[
+                let path = window.location.pathname;
+                let sub_path = path.substring(0, path.lastIndexOf('/'));
+                return sub_path + "/{{ navigation_path }}";
+              ]]]
           label: > 
             [[[         
               return `<ha-icon
@@ -98,7 +103,12 @@ card:
           template: {{ button_template }}
           tap_action: 
             action: navigate
-            navigation_path: {{ button_navigation_path }}
+            navigation_path: >
+          [[[
+            let path = window.location.pathname;
+            let sub_path = path.substring(0, path.lastIndexOf('/'));
+            return sub_path + "/{{ button_navigation_path }}";
+          ]]]
         {% elif type and type == 'include' %}
         !include
           - ../../{{ path }}

--- a/dwains-theme/views/partials/header_grid.yaml
+++ b/dwains-theme/views/partials/header_grid.yaml
@@ -104,11 +104,11 @@ card:
           tap_action: 
             action: navigate
             navigation_path: >
-          [[[
-            let path = window.location.pathname;
-            let sub_path = path.substring(0, path.lastIndexOf('/'));
-            return sub_path + "/{{ button_navigation_path }}";
-          ]]]
+              [[[
+                let path = window.location.pathname;
+                let sub_path = path.substring(0, path.lastIndexOf('/'));
+                return sub_path + "/{{ button_navigation_path }}";
+              ]]]
         {% elif type and type == 'include' %}
         !include
           - ../../{{ path }}


### PR DESCRIPTION
I wanted to allow dwains-theme to run alongside other lovelace dashboards. 
I also wanted dwains-theme to be default, ie. the path is "/lovelace" vice "/dwains-theme"

This was not completely possible based on hard navigation links.

This corrects it, and allows the dashboard to function under any path.