### PR TITLE
Add Tracking to Map

### DIFF
--- a/dwains-theme/views/main/persons/person.yaml
+++ b/dwains-theme/views/main/persons/person.yaml
@@ -81,6 +81,12 @@
               {% if person["show_map"] != 'false' %}
               - type: map
                 aspect_ratio: 16x9
+                hours_to_show: |
+                  {% if person["map_hours_to_show"] %}
+                    {{ person["map_hours_to_show"]|int }}
+                  {% else %}
+                    0
+                  {% endif %}
                 entities:
                   - {{ person["track"] }}
               {% endif %}


### PR DESCRIPTION
Fixes #182 

Adds a config option to person "map_hours_to_show".
If not included, default is used which disables tracking, otherwise the # hours configured shows.