### PR TITLE
Correct batteries with string values. Add color gradient to batteries.

### DIFF
--- a/dwains-theme/views/main/more_page/house_data/batteries.yaml
+++ b/dwains-theme/views/main/more_page/house_data/batteries.yaml
@@ -37,8 +37,10 @@
                     entity: this.entity_id
                     icon: >
                       [[[ 
+                        let conf = {{ _d_t_config.global["battery_empty_strings"] | tojson }};
+                        let nok_states = (Array.isArray(conf) && conf.length) ? conf : 'unknown';
                         if(states[`this.entity_id`]){
-                          if (states[`this.entity_id`].state == 'unknown'){
+                          if (nok_states.includes(states[`this.entity_id`].state)){
                             return 'mdi:battery-alert';
                           } else if (states[`this.entity_id`].state != 'unknown' && states[`this.entity_id`].state <= 10) {
                             return 'mdi:battery-outline';
@@ -50,6 +52,26 @@
                           }
                         }
                       ]]]
+                    styles:
+                      icon:
+                        - color: >
+                            [[[
+                              let conf = {{ _d_t_config.global["battery_empty_strings"] | tojson }};
+                              let nok_states = (Array.isArray(conf) && conf.length) ? conf : 'unknown';
+                              if (nok_states.includes(states[`this.entity_id`].state)) return '#ff0000';
+                              else if (entity.state <= 0) return '#ff0000';
+                              else if (entity.state <= 10) return '#ff5b00';
+                              else if (entity.state <= 20) return '#ff8a00';
+                              else if (entity.state <= 30) return '#ffb300';
+                              else if (entity.state <= 40) return '#ffda00';
+                              else if (entity.state <= 50) return '#ffff00';
+                              else if (entity.state <= 60) return '#e3ff00';
+                              else if (entity.state <= 70) return '#c3ff00';
+                              else if (entity.state <= 80) return '#9eff00';
+                              else if (entity.state <= 90) return '#6fff00';
+                              else if (entity.state <= 100) return '#00ff00';
+                              else return '#00ff00';
+                            ]]]
                 - type: custom:button-card
                   color_type: blank-card
                   aspect_ratio: 1/1


### PR DESCRIPTION
Adds a global config option "battery_empty_strings" to identify the empty value of batteries that return String values.

A few known integrations are Fitbit, Nest, and ZHA.

[Fitbit](https://github.com/home-assistant/core/blob/0427d87ba445bdd7646a4998ef6f3789aa1001e4/homeassistant/components/fitbit/sensor.py#L153) returns High, Medium, Low, and Empty. 

[Nest](https://developers.nest.com/reference/api-smoke-co-alarm#battery_health) returns battery health as "ok" and "replace".

[ZHA device_tracker](https://github.com/home-assistant/core/blob/0427d87ba445bdd7646a4998ef6f3789aa1001e4/homeassistant/components/zha/device_tracker.py#L52) returns "None" if the tracker left the house.

ZHA also returns "unavailable" if a device is dead and the server has been restarted as it cannot be reached.

Additionally, i think a color gradient for the batteries is easier on the eye to identify depleted batteries.

![Screenshot from 2020-08-08 09-09-22](https://user-images.githubusercontent.com/1853884/89711341-bb8a3300-d957-11ea-8a77-746a4c41f3fa.png)
