### PR TITLE
Add weather page and link to it from weather widget.

### DIFF
--- a/dwains-theme/resources/main.yaml
+++ b/dwains-theme/resources/main.yaml
@@ -5,7 +5,7 @@
 - type: module
   url: /local/dwains-theme/plugins/dwains-flexbox-card/dwains-flexbox-card.js?v=1.0.2
 - type: module
-  url: /local/dwains-theme/plugins/dwains-weather-card/dwains-weather-card.js?v=0.0.2
+  url: /local/dwains-theme/plugins/dwains-weather-card/dwains-weather-card.js?v=0.0.3
 - type: module
   url: /local/dwains-theme/plugins/dwains-notification-card/dwains-notification-card.js?v=0.0.2
 - type: module

--- a/dwains-theme/translations/en.yaml
+++ b/dwains-theme/translations/en.yaml
@@ -105,3 +105,6 @@ en:
 
   alarm:
     title: 'Alarm'
+
+  weather:
+    title: 'Weather'

--- a/dwains-theme/views/main/more_page/weather.yaml
+++ b/dwains-theme/views/main/more_page/weather.yaml
@@ -1,0 +1,48 @@
+# dwains_theme
+
+{% if _d_t_config.global["weather"] %}
+- title: {{ _d_t_trans.weather.title }}
+  path: more_page_weather
+  panel: true
+  cards:    
+    - type: custom:mod-card
+      style: | 
+        ha-card {
+          max-width: 1465px;
+          padding-bottom: 50px;
+          margin: 0 auto;
+          font-family: "Open Sans", sans-serif !important;
+        }
+      card:
+        type: vertical-stack
+        cards:
+          #Header
+          - !include
+            - ../../partials/header.yaml
+            - title: {{ _d_t_trans.weather.title }}
+              subtitle: {{ _d_t_trans.home.title }}
+              navigation_path: home  
+
+          #Start of weather page
+          - type: custom:dwains-flexbox-card
+            padding: true
+            items_classes: 'col-xs-12'
+            cards:
+              - type: weather-forecast
+                entity: {{ _d_t_config.global["weather"] }}
+
+          {% if _d_t_config.global["weather_radar"] %}
+          - type: custom:dwains-flexbox-card
+            padding: true
+            items_classes: 'col-xs-6'
+            cards:
+              {% for radar in _d_t_config.global["weather_radar"] %}
+
+              - entity: {{ radar }}
+                type: picture-entity
+                show_state: false
+              {% endfor %}
+
+          {% endif %}
+
+{% endif %}

--- a/www/dwains-theme/plugins/dwains-weather-card/dwains-weather-card.js
+++ b/www/dwains-theme/plugins/dwains-weather-card/dwains-weather-card.js
@@ -9,7 +9,7 @@ import {
     css
   } from "https://unpkg.com/lit-element@2.0.1/lit-element.js?module";
 
-const VERSION = '0.0.2';
+const VERSION = '0.0.3';
 
 const windDirections = [
   "N",
@@ -319,7 +319,14 @@ class DwainsWeatherCard extends LitElement {
   }
 
   _handleClick() {
-    fireEvent(this, "hass-more-info", { entityId: this._config.entity });
+    //fireEvent(this, "hass-more-info", { entityId: this._config.entity });
+    let e;
+    let path = window.location.pathname;
+    let nav_path = path.substring(0, path.lastIndexOf('/')) + "/more_page_weather";
+    window.history.pushState(null, '', nav_path);
+    e = new Event('location-changed', { composed: true });
+    e.detail = { replace: false };
+    window.dispatchEvent(e);
   }
   
   getCardSize() {


### PR DESCRIPTION
Add weather page to /lovelace-panel-name/more_info_weather
Link weather widget to new page.
Use hass built in weather card.
Add ability to define radar or camera to display. Infinite number of cameras. (2 looks best) Must use a list.
**Note: en translation for weather done, others need to be completed.**

global config yaml:
```yaml
  weather: weather.weather # Configure a weather entity see HA docs for more info.
  weather_radar:
    - camera.ne_weather_radar
    - camera.us_weather_radar

```
![weather](https://user-images.githubusercontent.com/1853884/89713058-1a08de80-d963-11ea-8012-b7fcd3ab552f.png)

