### PR TITLE
Homepage icons

### DIFF
--- a/dwains-theme/configs-samples/icons.yaml
+++ b/dwains-theme/configs-samples/icons.yaml
@@ -35,9 +35,12 @@
 #   motion_on: 'mdi:help'
 #   motion_off: 'mdi:help'
 
-#   cover: 'mdi:help'
+#   cover_open: 'mdi:help'
+#   cover_moving: 'mdi:help'
+#   cover_closed: 'mdi:help'
 
-#   device: 'mdi:help'
+#   device_on: 'mdi:help'
+#   device_off: 'mdi:help'
 
 #   media_player: 'mdi:help'
   

--- a/dwains-theme/views/main/01.homepage.yaml
+++ b/dwains-theme/views/main/01.homepage.yaml
@@ -500,7 +500,37 @@
                       {% if devices.hasLock == true %}
                       - type: custom:button-card
                         template: homepage_device
-                        icon: "{{ _d_t_icons.lock_unlocked|default('mdi:lock-open-variant-outline') }}"
+                        icon: >
+                          [[[
+                            var openLocks = 0;
+
+                            {% for room in _d_t_config.rooms %}                        
+                              //Do some things for the locks
+                              {% if room["lock"] %}
+                                {% if room["lock"].split('.')[0] == 'lock' %}
+                                //This room has only 1 lock
+                                  if(states['{{ room["lock"] }}'] && states['{{ room["lock"] }}'].state == 'unlocked') {
+                                    openLocks++;
+                                  }
+                                {% elif room["lock"].split('.')[0] == 'group' %}
+                                //This room has group of locks
+                                  if(states['{{ room["lock"] }}']){
+                                    states['{{ room["lock"] }}'].attributes['entity_id'].forEach(function(entity){
+                                      if(states[entity] && states[entity].state == 'unlocked'){
+                                        openLocks++;
+                                      }
+                                    });  
+                                  }
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+
+                            if(openLocks > 0){
+                              return "{{ _d_t_icons.lock_unlocked|default('mdi:lock-open-variant-outline') }}";
+                            } else {
+                              return "{{ _d_t_icons.lock_locked|default('mdi:lock') }}";
+                            }
+                          ]]]
                         name: {{ _d_t_trans.lock.title_plural }}
                         tap_action: 
                           action: navigate
@@ -541,7 +571,39 @@
                       {% if devices.hasSafety == true %}
                       - type: custom:button-card
                         template: homepage_device
-                        icon: "{{ _d_t_icons.safety_ok|default('mdi:shield-check') }}"
+                        icon: >
+                          [[[
+                            var notOkSafety = 0;
+                            let conf = {{ _d_t_config.global["safety_ok_strings"] | tojson }};
+                            let ok_states = (Array.isArray(conf) && conf.length) ? conf : 'off';
+
+                            {% for room in _d_t_config.rooms %}
+                              //Do some things for the Safeties
+                              {% if room["safety"] %}
+                                {% if room["safety"].split('.')[0] != 'group' %}
+                                //This room has only 1 safety device
+                                  if(states['{{ room["safety"] }}'] && (! ok_states.includes( states['{{ room["safety"] }}'].state ))) {
+                                    notOkSafety++;
+                                  }
+                                {% else %}
+                                //This room has group of Safeties
+                                  if(states['{{ room["safety"] }}']){
+                                    states['{{ room["safety"] }}'].attributes['entity_id'].forEach(function(entity){
+                                      if(states[entity] && (! ok_states.includes( states[entity].state ))){
+                                        notOkSafety++;
+                                      }
+                                    });  
+                                  }
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+
+                            if(notOkSafety > 0){
+                              return "{{ _d_t_icons.safety_alert|default('mdi:shield-alert-outline') }}";
+                            } else {  
+                              return "{{ _d_t_icons.safety_ok|default('mdi:shield-check') }}";
+                            }
+                          ]]]
                         name: {{ _d_t_trans.safety.title_plural }}
                         tap_action: 
                           action: navigate
@@ -584,7 +646,37 @@
                       {% if devices.hasLight == true %}
                       - type: custom:button-card
                         template: homepage_device
-                        icon: "{{ _d_t_icons.light_off|default('mdi:lightbulb') }}"
+                        icon: >
+                          [[[
+                            var onLights = 0;
+
+                            {% for room in _d_t_config.rooms %}
+                              //Do some things for the lights
+                              {% if room["light"] %}
+                                {% if room["light"].split('.')[0] == 'light' or room["light"].split('.')[0] == 'switch' %}
+                                //This room has only 1 light
+                                  if(states['{{ room["light"] }}'] && states['{{ room["light"] }}'].state == 'on') {
+                                    onLights++;
+                                  }
+                                {% else %}
+                                //This room has group of lights
+                                  if(states['{{ room["light"] }}']){
+                                    states['{{ room["light"] }}'].attributes['entity_id'].forEach(function(entity){
+                                      if(states[entity] && states[entity].state == 'on'){
+                                        onLights++;
+                                      }
+                                    });  
+                                  }
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+
+                            if(onLights > 0){
+                              return "{{ _d_t_icons.light_on|default('mdi:lightbulb') }}";
+                            } else {  
+                              return "{{ _d_t_icons.light_off|default('mdi:lightbulb-outline') }}";
+                            }
+                          ]]]
                         name: {{ _d_t_trans.light.title_plural }}
                         tap_action: 
                           action: navigate
@@ -664,7 +756,37 @@
                       {% if devices.hasCover == true %}
                       - type: custom:button-card
                         template: homepage_device
-                        icon: "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+                        icon: >
+                          [[[
+                            var openCovers = 0;
+
+                            {% for room in _d_t_config.rooms %}                        
+                              //Do some things for the covers
+                              {% if room["cover"] %}
+                                {% if room["cover"].split('.')[0] == 'cover' %}
+                                //This room has only 1 cover
+                                  if(states['{{ room["cover"] }}'] && states['{{ room["cover"] }}'].state == 'open') {
+                                    openCovers++;
+                                  }
+                                {% elif room["cover"].split('.')[0] == 'group' %}
+                                //This room has group of covers
+                                  if(states['{{ room["cover"] }}']){
+                                    states['{{ room["cover"] }}'].attributes['entity_id'].forEach(function(entity){
+                                      if(states[entity] && states[entity].state == 'open'){
+                                        openCovers++;
+                                      }
+                                    });  
+                                  }
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+                        
+                            if(openCovers >= 1){
+                              return "{{ _d_t_icons.cover_open|default('mdi:window-shutter-open') }}";
+                            } else {  
+                              return "{{ _d_t_icons.cover_closed|default('mdi:window-shutter') }}";
+                            }
+                          ]]]
                         name: {{ _d_t_trans.cover.title_plural }}
                         tap_action: 
                           action: navigate
@@ -705,7 +827,37 @@
                       {% if devices.hasDevice == true %}
                       - type: custom:button-card
                         template: homepage_device
-                        icon: "{{ _d_t_icons.device|default('mdi:power-plug') }}"
+                        icon: >
+                          [[[
+                            var onDevices = 0;
+
+                            {% for room in _d_t_config.rooms %}
+                              //Do some things for the Devices
+                              {% if room["device"] %}
+                                {% if room["device"].split('.')[0] != 'group' %}
+                                //This room has only 1 device
+                                  if(states['{{ room["device"] }}'] && states['{{ room["device"] }}'].state == 'on') {
+                                    onDevices++;
+                                  }
+                                {% else %}
+                                //This room has group of Devices
+                                  if(states['{{ room["device"] }}']){
+                                    states['{{ room["device"] }}'].attributes['entity_id'].forEach(function(entity){
+                                      if(states[entity] && states[entity].state == 'on'){
+                                        onDevices++;
+                                      }
+                                    });  
+                                  }
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+
+                            if(onDevices > 0){
+                              return "{{ _d_t_icons.device_on|default('mdi:power-plug') }}";
+                            } else {  
+                              return "{{ _d_t_icons.device_off|default('mdi:power-plug-outline') }}";
+                            }
+                          ]]]
                         name: {{ _d_t_trans.device.title_plural }}
                         tap_action: 
                           action: navigate

--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -35,7 +35,7 @@
             - ../../partials/header.yaml
             - title: {{ room["name"] }}
               subtitle: {{ _d_t_trans.home.title }}
-              navigation_path: home  
+              navigation_path: home
           {% endif %}
           #Subheader with room information
           {% if room["motion"] or room["door"] or room["window"] %}
@@ -512,7 +512,14 @@
               - type: custom:button-card
                 entity: {{ room["cover"] }}
                 template: rooms_child
-                icon: "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+                icon: "{{ _d_t_icons.cover_closed|default('mdi:window-shutter') }}"
+                state:
+                  - value: 'open'
+                    icon: "{{ _d_t_icons.cover_closed|default('mdi:window-shutter-open') }}"
+                  - value: 'opening'
+                    icon: "{{ _d_t_icons.cover_moving|default('mdi:window-shutter-alert') }}"
+                  - value: 'closing'
+                    icon: "{{ _d_t_icons.cover_moving|default('mdi:window-shutter-alert') }}"
                 tap_action: 
                   action: navigate
                   navigation_path: {{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}_cover
@@ -520,8 +527,10 @@
                 label: >
                   [[[ 
                     if(entity){
+                      let position = states['{{ room["cover"] }}'].attributes.current_position;
+                      let position_text = (position =! 'undefined') ? ' ' + position + '%' : '';
                       if(entity.state == 'open'){
-                        return hass.localize('component.cover.state._.open') + ' ' + states['{{ room["cover"] }}'].attributes.current_position + '%';
+                        return hass.localize('component.cover.state._.open') + position_text;
                       } else if(entity.state == 'closed') {
                         return hass.localize('component.cover.state._.closed');
                       } else {
@@ -560,7 +569,10 @@
               - type: custom:button-card
                 entity: {{ room["device"] }}
                 template: rooms_child
-                icon: "{{ _d_t_icons.device|default('mdi:power-plug') }}"
+                icon: "{{ _d_t_icons.device_on|default('mdi:power-plug-outline') }}"
+                state:
+                  - value: 'on'
+                    icon: "{{ _d_t_icons.device_off|default('mdi:power-plug-outline') }}"
                 {% if room["device"].split('.')[0] != 'group' %}
                 # this room has only 1 device
                 tap_action:

--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -572,7 +572,7 @@
                 icon: "{{ _d_t_icons.device_on|default('mdi:power-plug-outline') }}"
                 state:
                   - value: 'on'
-                    icon: "{{ _d_t_icons.device_off|default('mdi:power-plug-outline') }}"
+                    icon: "{{ _d_t_icons.device_off|default('mdi:power-plug') }}"
                 {% if room["device"].split('.')[0] != 'group' %}
                 # this room has only 1 device
                 tap_action:

--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -278,12 +278,12 @@
               - type: custom:button-card
                 entity: {{ room["light"] }}
                 template: rooms_child
+                {% if room["light"].split('.')[0] == 'light' %}
+                # this room has only 1 light (light entity)
                 icon: "{{ _d_t_icons.light_off|default('mdi:lightbulb-outline') }}"
                 state:
                   - value: 'on'
                     icon: "{{ _d_t_icons.light_on|default('mdi:lightbulb') }}"
-                {% if room["light"].split('.')[0] == 'light' %}
-                # this room has only 1 light (light entity)
                 tap_action:
                   action: toggle
                   haptic: light 
@@ -342,6 +342,27 @@
                 double_tap_action:
                   action: toggle
                   haptic: light 
+                icon: >
+                  [[[
+                    if(entity){
+                      const entitiesFromGroup = states['{{ room["light"] }}'].attributes['entity_id'];
+                      var onLights = 0;
+                      entitiesFromGroup.forEach(function(entity){
+                        if(states[entity] && states[entity].state == 'on'){
+                          onLights++;
+                        }
+                      });  
+                      if(onLights >= 1){
+                        return "{{ _d_t_icons.light_on|default('mdi:lightbulb-group') }}";
+                      } else {
+                        return "{{ _d_t_icons.light_off|default('mdi:lightbulb-group-outline') }}";
+                      }
+
+                    } else {
+                      console.log("Invalid rooms.yaml:{{ room["name"] }}.light entity!");
+                      return 'Entity error!';
+                    }
+                  ]]]
                 label: >
                   [[[
                     if(entity){

--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -35,7 +35,7 @@
             - ../../partials/header.yaml
             - title: {{ room["name"] }}
               subtitle: {{ _d_t_trans.home.title }}
-              navigation_path: home
+              navigation_path: home  
           {% endif %}
           #Subheader with room information
           {% if room["motion"] or room["door"] or room["window"] %}


### PR DESCRIPTION
Closes #149 
Will conflict with #172 

Adds icon config for device and cover.
Modifies homepage device for Lock, Safety, Light, Cover, and Device icons based on state.
Modifies rooms for Cover and Device icons based on state.

Fixes room cover text for devices without position.

Uses different icon in rooms to show group of lights.