### PR TITLE
Page Entities: Add toggle for switch and light, and more info on hold.

### DIFF
--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -762,10 +762,17 @@
               - type: custom:button-card
                 entity: {{ more_entity["entity"] }}
                 template: room_more_entity
+                {% if more_entity["entity"].split('.')[0] in ('switch', 'light') %}
+                tap_action:
+                    action: toggle
+                hold_action:
+                    action: more-info
+                {% else %}
                 tap_action:
                   !include 
                     - ../../popups/more-info.yaml
                     - entity: {{ more_entity["entity"] }}
+                {% endif %}
               {% endfor %}
               {% endif %}
 {% endfor %}


### PR DESCRIPTION
Fixes page_entities  switch and light.

Used to display more info popup, now will toggle on/off and show more info on hold (long press).